### PR TITLE
Update README.md

### DIFF
--- a/Django Application/README.md
+++ b/Django Application/README.md
@@ -38,7 +38,7 @@ Django >= v3.0
 
 ### Step 4: Install requirements
 
-`pip install requirements.txt`
+`pip install -r requirements.txt`
 
 ### Step 5: Copy Models
 


### PR DESCRIPTION
Changed the syntax for installing requirements.txt

Updated syntax to : pip install -r requirements.txt
without -r, pip thinks you want to install a package named requirements.txt, which doesn't exist.